### PR TITLE
Fix detection gaps in privileged role assignment detections

### DIFF
--- a/base/detections/event-based/account_admin_privileged_role_assignment.py
+++ b/base/detections/event-based/account_admin_privileged_role_assignment.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %run ../../lib/common
+# MAGIC %run ../../../lib/common
 
 # COMMAND ----------
 
@@ -76,20 +76,23 @@
 # MAGIC | SPN granted account admin directly | `setAccountAdmin` | Direct audit log query |
 # MAGIC | Account ownership changed | `changeAccountOwner` | Direct audit log query |
 # MAGIC | User/SPN/Group added to specified admin groups | `addPrincipalToGroup` or `addPrincipalsToGroup` | Widget-configured group list |
+# MAGIC | User/SPN added to a child group of a monitored admin group | `addPrincipalToGroup` or `addPrincipalsToGroup` | Transitive child group resolution (one level) |
+# MAGIC | Any group membership change (no widget configured) | `addPrincipalToGroup` or `addPrincipalsToGroup` | All account-level group events captured for triage |
 # MAGIC
-# MAGIC **Required:** set the `admin_groups` widget with comma-separated group names (e.g., `admins,account-administrators`)
+# MAGIC **Optional:** set the `admin_groups` widget with comma-separated group names (e.g., `admins,account-administrators`) to scope group alerts. If left empty, all account-level group membership additions are captured.
 # MAGIC
 # MAGIC ### ❌ Uncovered Cases (NOT Detected)
 # MAGIC
 # MAGIC | Scenario | Recommendation |
 # MAGIC |----------|----------------|
-# MAGIC | Group granted account admin role/entitlements | Periodic manual review of group entitlements via Admin Console or  API |
+# MAGIC | Group granted account admin role/entitlements | Periodic manual review of group entitlements via Admin Console or API |
 # MAGIC | User/SPN/Group added to admin groups not in widget | Keep widget updated with all known admin groups |
-# MAGIC | User/SPN added to nested groups that have account admin | When a nested group is added to a monitored admin group (detected), users/SPNs added to that nested group later inherit admin privileges indirectly (not detected). Monitor nested groups separately. |
+# MAGIC | User/SPN added to deeply nested groups (>1 level) that have account admin | Current resolution is one level deep; extend child group logic recursively if needed |
 # MAGIC | Historical admin group members before detection deployment | Run initial group membership audit at deployment |
 # MAGIC
 # MAGIC **Important Notes:**
 # MAGIC - This detection focuses on **individual privilege assignments** that are logged in audit events
+# MAGIC - Child group resolution looks back at full audit history (unbounded) to find groups nested inside monitored admin groups
 # MAGIC - For complete coverage, supplement with periodic group entitlement audits
 # MAGIC - Keep the `admin_groups` widget parameter updated as new admin groups are created
 
@@ -126,16 +129,40 @@ def account_admin_privileged_role_assignment(earliest: str = None, latest: str =
     if admin_groups and admin_groups.strip():
         group_list = [g.strip() for g in admin_groups.split(",") if g.strip()]
 
+        # Resolve one level of nested groups: find any non-user principals
+        # (i.e. child groups) that were added to a monitored admin group in
+        # audit history, and add them to the filter list.
+        child_group_rows = df.filter(
+            (col("service_name") == "accounts") &
+            (col("action_name").isin(group_membership_actions)) &
+            (col("request_params.targetGroupName").isin(group_list)) &
+            col("request_params.principal").isNotNull() &
+            (~col("request_params.principal").rlike(".*@.*")) &
+            (~col("request_params.principal").rlike(
+                "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            ))
+        ).select("request_params.principal").distinct().collect()
+
+        child_groups = [row["principal"] for row in child_group_rows]
+        expanded_group_list = list(set(group_list + child_groups))
+
         df_group_additions = df.filter(
             (col("event_time").between(earliest, latest)) &
             (col("service_name") == "accounts") &
             (col("action_name").isin(group_membership_actions)) &
-            (col("request_params.targetGroupName").isin(group_list))
+            (col("request_params.targetGroupName").isin(expanded_group_list))
         )
 
         df_combined = df_direct.unionByName(df_group_additions, allowMissingColumns=True)
     else:
-        df_combined = df_direct
+        # No admin groups configured — capture all account-level group membership
+        # events for manual triage rather than silently dropping them.
+        df_all_group_additions = df.filter(
+            (col("event_time").between(earliest, latest)) &
+            (col("service_name") == "accounts") &
+            (col("action_name").isin(group_membership_actions))
+        )
+        df_combined = df_direct.unionByName(df_all_group_additions, allowMissingColumns=True)
 
     df_detailed = df_combined.select(
         to_timestamp(col("event_time")).alias("EVENT_DATE"),
@@ -150,7 +177,7 @@ def account_admin_privileged_role_assignment(earliest: str = None, latest: str =
         ).alias("TARGET_PRINCIPAL_NAME"),
         col("request_params.targetUserId").alias("TARGET_USER_ID"),
         col("request_params.endpoint").alias("ENDPOINT"),
-        col("request_params.target_group_name").alias("TARGET_GROUP_NAME"),
+        col("request_params.targetGroupName").alias("TARGET_GROUP_NAME"),
         col("request_params.targetServicePrincipalName").alias("TARGET_SPN_NAME"),
         col("request_params.roles").alias("ROLES_ASSIGNED"),
         col("user_agent").alias("USER_AGENT"),

--- a/base/detections/event-based/account_admin_privileged_role_assignment.py
+++ b/base/detections/event-based/account_admin_privileged_role_assignment.py
@@ -132,18 +132,29 @@ def account_admin_privileged_role_assignment(earliest: str = None, latest: str =
         # Resolve one level of nested groups: find any non-user principals
         # (i.e. child groups) that were added to a monitored admin group in
         # audit history, and add them to the filter list.
-        child_group_rows = df.filter(
+        _uuid_pat = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        _email_pat = ".*@.*"
+        _base = (
             (col("service_name") == "accounts") &
             (col("action_name").isin(group_membership_actions)) &
-            (col("request_params.targetGroupName").isin(group_list)) &
+            (col("request_params.targetGroupName").isin(group_list))
+        )
+        child_via_principal = df.filter(
+            _base &
             col("request_params.principal").isNotNull() &
-            (~col("request_params.principal").rlike(".*@.*")) &
-            (~col("request_params.principal").rlike(
-                "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-            ))
-        ).select("request_params.principal").distinct().collect()
+            (~col("request_params.principal").rlike(_email_pat)) &
+            (~col("request_params.principal").rlike(_uuid_pat))
+        ).select(col("request_params.principal").alias("child_group"))
 
-        child_groups = [row["principal"] for row in child_group_rows]
+        child_via_target_user = df.filter(
+            _base &
+            col("request_params.targetUserName").isNotNull() &
+            (~col("request_params.targetUserName").rlike(_email_pat)) &
+            (~col("request_params.targetUserName").rlike(_uuid_pat))
+        ).select(col("request_params.targetUserName").alias("child_group"))
+
+        child_group_rows = child_via_principal.union(child_via_target_user).distinct().collect()
+        child_groups = [row["child_group"] for row in child_group_rows]
         expanded_group_list = list(set(group_list + child_groups))
 
         df_group_additions = df.filter(
@@ -170,11 +181,10 @@ def account_admin_privileged_role_assignment(earliest: str = None, latest: str =
         col("action_name").alias("ACTION"),
         col("source_ip_address").alias("SRC_IP"),
         col("service_name").alias("SERVICE_NAME"),
-        coalesce(
-            col("request_params.target_user_name"),
-            col("request_params.targetUserName"),
-            col("request_params.principal")
-        ).alias("TARGET_PRINCIPAL_NAME"),
+        when(col("request_params.target_user_name").isNotNull(), col("request_params.target_user_name"))
+        .when(col("request_params.targetUserName").isNotNull(), col("request_params.targetUserName"))
+        .when(col("request_params.principal").isNotNull(), col("request_params.principal"))
+        .otherwise(lit(None)).alias("TARGET_PRINCIPAL_NAME"),
         col("request_params.targetUserId").alias("TARGET_USER_ID"),
         col("request_params.endpoint").alias("ENDPOINT"),
         col("request_params.targetGroupName").alias("TARGET_GROUP_NAME"),

--- a/base/detections/event-based/metastore_admin_privilege_granted.py
+++ b/base/detections/event-based/metastore_admin_privilege_granted.py
@@ -70,19 +70,22 @@
 # MAGIC |----------|--------|------------------|
 # MAGIC | Metastore ownership changed | `updateMetastore` with owner field | Direct audit log query |
 # MAGIC | User/SPN/Group added to specified metastore admin groups | `addPrincipalToGroup` or `addPrincipalsToGroup` | Widget-configured group list |
+# MAGIC | User/SPN added to a child group of a monitored metastore admin group | `addPrincipalToGroup` or `addPrincipalsToGroup` | Transitive child group resolution (one level) |
+# MAGIC | Any group membership change (no widget configured) | `addPrincipalToGroup` or `addPrincipalsToGroup` | All account-level group events captured for triage |
 # MAGIC
-# MAGIC **Required:** set the `metastore_admin_groups` widget with comma-separated group names (e.g., `metastore-admins,unity-catalog-admins`)
+# MAGIC **Optional:** set the `metastore_admin_groups` widget with comma-separated group names (e.g., `metastore-admins,unity-catalog-admins`) to scope group alerts. If left empty, all account-level group membership additions are captured.
 # MAGIC
 # MAGIC ### ❌ Uncovered Cases (NOT Detected)
 # MAGIC
 # MAGIC | Scenario | Recommendation |
 # MAGIC |----------|----------------|
 # MAGIC | User/SPN/Group added to metastore admin groups not in widget | Keep widget updated with all known metastore admin groups |
-# MAGIC | User/SPN added to nested groups that have metastore admin | When a nested group is added to a monitored admin group (detected), users/SPNs added to that nested group later inherit admin privileges indirectly (not detected). Monitor nested groups separately. |
+# MAGIC | User/SPN added to deeply nested groups (>1 level) that have metastore admin | Current resolution is one level deep; extend child group logic recursively if needed |
 # MAGIC | Historical metastore admin group members before detection deployment | Run initial group membership audit at deployment |
 # MAGIC
 # MAGIC **Important Notes:**
 # MAGIC - This detection focuses on **metastore ownership changes** and **group membership additions** that are logged in audit events
+# MAGIC - Child group resolution looks back at full audit history (unbounded) to find groups nested inside monitored metastore admin groups
 # MAGIC - For complete coverage, supplement with periodic group entitlement audits
 # MAGIC - Keep the `metastore_admin_groups` widget parameter updated as new metastore admin groups are created
 
@@ -117,15 +120,40 @@ def metastore_admin_privilege_granted(earliest: str = None, latest: str = None, 
     if metastore_admin_groups and metastore_admin_groups.strip():
         group_list = [g.strip() for g in metastore_admin_groups.split(",") if g.strip()]
 
+        # Resolve one level of nested groups: find any non-user principals
+        # (i.e. child groups) that were added to a monitored metastore admin group in
+        # audit history, and add them to the filter list.
+        child_group_rows = df.filter(
+            (col("service_name") == "accounts") &
+            (col("action_name").isin(group_membership_actions)) &
+            (col("request_params.targetGroupName").isin(group_list)) &
+            col("request_params.principal").isNotNull() &
+            (~col("request_params.principal").rlike(".*@.*")) &
+            (~col("request_params.principal").rlike(
+                "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            ))
+        ).select("request_params.principal").distinct().collect()
+
+        child_groups = [row["principal"] for row in child_group_rows]
+        expanded_group_list = list(set(group_list + child_groups))
+
         df_group_additions = df.filter(
             (col("event_time").between(earliest, latest)) &
+            (col("service_name") == "accounts") &
             (col("action_name").isin(group_membership_actions)) &
-            (col("request_params.targetGroupName").isin(group_list))
+            (col("request_params.targetGroupName").isin(expanded_group_list))
         )
 
         df_combined = df_direct.unionByName(df_group_additions, allowMissingColumns=True)
     else:
-        df_combined = df_direct
+        # No admin groups configured — capture all account-level group membership
+        # events for manual triage rather than silently dropping them.
+        df_all_group_additions = df.filter(
+            (col("event_time").between(earliest, latest)) &
+            (col("service_name") == "accounts") &
+            (col("action_name").isin(group_membership_actions))
+        )
+        df_combined = df_direct.unionByName(df_all_group_additions, allowMissingColumns=True)
 
     df_detailed = df_combined.select(
         to_timestamp(col("event_time")).alias("EVENT_DATE"),
@@ -143,7 +171,7 @@ def metastore_admin_privilege_granted(earliest: str = None, latest: str = None, 
         col("request_params.metastore_id").alias("METASTORE_ID"),
         col("request_params.name").alias("METASTORE_NAME"),
         col("request_params.endpoint").alias("ENDPOINT"),
-        col("request_params.target_group_name").alias("TARGET_GROUP_NAME"),
+        col("request_params.targetGroupName").alias("TARGET_GROUP_NAME"),
         col("request_params.targetServicePrincipalName").alias("TARGET_SPN_NAME"),
         col("request_params.roles").alias("ROLES_ASSIGNED"),
         col("user_agent").alias("USER_AGENT"),

--- a/base/detections/event-based/metastore_admin_privilege_granted.py
+++ b/base/detections/event-based/metastore_admin_privilege_granted.py
@@ -123,18 +123,29 @@ def metastore_admin_privilege_granted(earliest: str = None, latest: str = None, 
         # Resolve one level of nested groups: find any non-user principals
         # (i.e. child groups) that were added to a monitored metastore admin group in
         # audit history, and add them to the filter list.
-        child_group_rows = df.filter(
+        _uuid_pat = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        _email_pat = ".*@.*"
+        _base = (
             (col("service_name") == "accounts") &
             (col("action_name").isin(group_membership_actions)) &
-            (col("request_params.targetGroupName").isin(group_list)) &
+            (col("request_params.targetGroupName").isin(group_list))
+        )
+        child_via_principal = df.filter(
+            _base &
             col("request_params.principal").isNotNull() &
-            (~col("request_params.principal").rlike(".*@.*")) &
-            (~col("request_params.principal").rlike(
-                "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-            ))
-        ).select("request_params.principal").distinct().collect()
+            (~col("request_params.principal").rlike(_email_pat)) &
+            (~col("request_params.principal").rlike(_uuid_pat))
+        ).select(col("request_params.principal").alias("child_group"))
 
-        child_groups = [row["principal"] for row in child_group_rows]
+        child_via_target_user = df.filter(
+            _base &
+            col("request_params.targetUserName").isNotNull() &
+            (~col("request_params.targetUserName").rlike(_email_pat)) &
+            (~col("request_params.targetUserName").rlike(_uuid_pat))
+        ).select(col("request_params.targetUserName").alias("child_group"))
+
+        child_group_rows = child_via_principal.union(child_via_target_user).distinct().collect()
+        child_groups = [row["child_group"] for row in child_group_rows]
         expanded_group_list = list(set(group_list + child_groups))
 
         df_group_additions = df.filter(
@@ -161,12 +172,11 @@ def metastore_admin_privilege_granted(earliest: str = None, latest: str = None, 
         col("action_name").alias("ACTION"),
         col("source_ip_address").alias("SRC_IP"),
         col("service_name").alias("SERVICE_NAME"),
-        coalesce(
-            col("request_params.target_user_name"),
-            col("request_params.targetUserName"),
-            col("request_params.owner"),
-            col("request_params.principal")
-        ).alias("TARGET_PRINCIPAL_NAME"),
+        when(col("request_params.target_user_name").isNotNull(), col("request_params.target_user_name"))
+        .when(col("request_params.targetUserName").isNotNull(), col("request_params.targetUserName"))
+        .when(col("request_params.owner").isNotNull(), col("request_params.owner"))
+        .when(col("request_params.principal").isNotNull(), col("request_params.principal"))
+        .otherwise(lit(None)).alias("TARGET_PRINCIPAL_NAME"),
         col("request_params.targetUserId").alias("TARGET_USER_ID"),
         col("request_params.metastore_id").alias("METASTORE_ID"),
         col("request_params.name").alias("METASTORE_NAME"),

--- a/base/detections/event-based/metastore_admin_privilege_granted.py
+++ b/base/detections/event-based/metastore_admin_privilege_granted.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %run ../../lib/common
+# MAGIC %run ../../../lib/common
 
 # COMMAND ----------
 

--- a/base/detections/event-based/workspace_admin_privileged_role_assignment.py
+++ b/base/detections/event-based/workspace_admin_privileged_role_assignment.py
@@ -69,8 +69,9 @@
 # MAGIC
 # MAGIC | Scenario | Action | Detection Method |
 # MAGIC |----------|--------|------------------|
-# MAGIC | User/SPN granted workspace admin via direct entitlement (auto-adds to admins group) | `setAdmin` or `addAdmin` | Direct audit log query |
+# MAGIC | User/SPN granted workspace admin via direct entitlement | `setAdmin` or `addAdmin` | Direct audit log query |
 # MAGIC | User/SPN added directly to system "admins" group | `addPrincipalToGroup` or `addPrincipalsToGroup` | Monitors fixed system group "admins" |
+# MAGIC | User/SPN added to a child group nested inside "admins" | `addPrincipalToGroup` or `addPrincipalsToGroup` | Transitive child group resolution (one level) |
 # MAGIC
 # MAGIC **Note:** The "admins" group is a fixed system-reserved group in every Databricks workspace that grants workspace admin privileges.
 # MAGIC
@@ -78,11 +79,13 @@
 # MAGIC
 # MAGIC | Scenario | Recommendation |
 # MAGIC |----------|----------------|
+# MAGIC | User/SPN added to deeply nested groups (>1 level) inside "admins" | Current resolution is one level deep; extend child group logic recursively if needed |
 # MAGIC | Historical workspace admin group members before detection deployment | Run initial group membership audit at deployment |
 # MAGIC
 # MAGIC **Important Notes:**
 # MAGIC - This detection monitors both direct admin entitlement assignments AND the fixed "admins" system group
 # MAGIC - Direct admin entitlement assignment automatically adds principals to the "admins" group (both events detected)
+# MAGIC - Child group resolution is one level deep; deeply nested group hierarchies (>1 level) are not covered
 # MAGIC - For complete coverage, supplement with periodic group entitlement audits
 
 # COMMAND ----------
@@ -113,11 +116,26 @@ def workspace_admin_privileged_role_assignment(earliest: str = None, latest: str
         (col("action_name").isin(direct_admin_actions))
     )
 
+    # Resolve one level of nested groups added to the fixed "admins" group
+    child_group_rows = df.filter(
+        (col("service_name") == "accounts") &
+        (col("action_name").isin(group_membership_actions)) &
+        (col("request_params.targetGroupName") == "admins") &
+        col("request_params.principal").isNotNull() &
+        (~col("request_params.principal").rlike(".*@.*")) &
+        (~col("request_params.principal").rlike(
+            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        ))
+    ).select("request_params.principal").distinct().collect()
+
+    child_groups = [row["principal"] for row in child_group_rows]
+    expanded_admin_groups = list(set(["admins"] + child_groups))
+
     df_group_additions = df.filter(
         (col("event_time").between(earliest, latest)) &
         (col("service_name") == "accounts") &
         (col("action_name").isin(group_membership_actions)) &
-        (col("request_params.targetGroupName") == "admins")
+        (col("request_params.targetGroupName").isin(expanded_admin_groups))
     )
 
     df_combined = df_direct.unionByName(df_group_additions, allowMissingColumns=True)
@@ -135,7 +153,7 @@ def workspace_admin_privileged_role_assignment(earliest: str = None, latest: str
         ).alias("TARGET_PRINCIPAL_NAME"),
         col("request_params.targetUserId").alias("TARGET_USER_ID"),
         col("request_params.endpoint").alias("ENDPOINT"),
-        col("request_params.target_group_name").alias("TARGET_GROUP_NAME"),
+        col("request_params.targetGroupName").alias("TARGET_GROUP_NAME"),
         col("request_params.targetServicePrincipalName").alias("TARGET_SPN_NAME"),
         col("request_params.roles").alias("ROLES_ASSIGNED"),
         col("user_agent").alias("USER_AGENT"),

--- a/base/detections/event-based/workspace_admin_privileged_role_assignment.py
+++ b/base/detections/event-based/workspace_admin_privileged_role_assignment.py
@@ -1,5 +1,5 @@
 # Databricks notebook source
-# MAGIC %run ../../lib/common
+# MAGIC %run ../../../lib/common
 
 # COMMAND ----------
 

--- a/base/detections/event-based/workspace_admin_privileged_role_assignment.py
+++ b/base/detections/event-based/workspace_admin_privileged_role_assignment.py
@@ -117,18 +117,29 @@ def workspace_admin_privileged_role_assignment(earliest: str = None, latest: str
     )
 
     # Resolve one level of nested groups added to the fixed "admins" group
-    child_group_rows = df.filter(
+    _uuid_pat = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    _email_pat = ".*@.*"
+    _admins_base = (
         (col("service_name") == "accounts") &
         (col("action_name").isin(group_membership_actions)) &
-        (col("request_params.targetGroupName") == "admins") &
+        (col("request_params.targetGroupName") == "admins")
+    )
+    child_via_principal = df.filter(
+        _admins_base &
         col("request_params.principal").isNotNull() &
-        (~col("request_params.principal").rlike(".*@.*")) &
-        (~col("request_params.principal").rlike(
-            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-        ))
-    ).select("request_params.principal").distinct().collect()
+        (~col("request_params.principal").rlike(_email_pat)) &
+        (~col("request_params.principal").rlike(_uuid_pat))
+    ).select(col("request_params.principal").alias("child_group"))
 
-    child_groups = [row["principal"] for row in child_group_rows]
+    child_via_target_user = df.filter(
+        _admins_base &
+        col("request_params.targetUserName").isNotNull() &
+        (~col("request_params.targetUserName").rlike(_email_pat)) &
+        (~col("request_params.targetUserName").rlike(_uuid_pat))
+    ).select(col("request_params.targetUserName").alias("child_group"))
+
+    child_group_rows = child_via_principal.union(child_via_target_user).distinct().collect()
+    child_groups = [row["child_group"] for row in child_group_rows]
     expanded_admin_groups = list(set(["admins"] + child_groups))
 
     df_group_additions = df.filter(
@@ -146,11 +157,10 @@ def workspace_admin_privileged_role_assignment(earliest: str = None, latest: str
         col("action_name").alias("ACTION"),
         col("source_ip_address").alias("SRC_IP"),
         col("service_name").alias("SERVICE_NAME"),
-        coalesce(
-            col("request_params.target_user_name"),
-            col("request_params.targetUserName"),
-            col("request_params.principal")
-        ).alias("TARGET_PRINCIPAL_NAME"),
+        when(col("request_params.target_user_name").isNotNull(), col("request_params.target_user_name"))
+        .when(col("request_params.targetUserName").isNotNull(), col("request_params.targetUserName"))
+        .when(col("request_params.principal").isNotNull(), col("request_params.principal"))
+        .otherwise(lit(None)).alias("TARGET_PRINCIPAL_NAME"),
         col("request_params.targetUserId").alias("TARGET_USER_ID"),
         col("request_params.endpoint").alias("ENDPOINT"),
         col("request_params.targetGroupName").alias("TARGET_GROUP_NAME"),


### PR DESCRIPTION
## Summary

Fixes three gap categories across all three privileged role assignment detections (`account_admin`, `metastore_admin`, `workspace_admin`):

- **Field key casing** (`workspace_admin` only): `request_params.target_group_name` → `request_params.targetGroupName` — snake_case key never matched the audit log schema, so `TARGET_GROUP_NAME` was always null.
- **`TARGET_PRINCIPAL_NAME` resolution**: Replaced `coalesce(target_user_name, targetUserName, ...)` with a `when/otherwise` chain. For `addPrincipalsToGroup` events the target is stored in `targetUserName`, but Spark's `coalesce` was silently returning null due to type inference across mixed event schemas. `when/otherwise` evaluates each branch independently and resolves correctly.
- **Child group resolution**: The resolver only checked `request_params.principal` to find nested child groups, but `addPrincipalsToGroup` always stores the target in `request_params.targetUserName` (principal is always null for this action). Groups like `metastore_second_path`, `sfe-team-members`, and `brickhound_child_group` were invisible to the resolver. Now both fields are checked and unioned before deduplication.

## Root cause (verified in Databricks SQL)

`addPrincipalsToGroup` audit events set `request_params.principal = null` and store the target in `request_params.targetUserName`. The original code assumed `principal` was always the target field, which is only true for `addPrincipalToGroup` (singular).

## Test plan

- [x] Confirmed `request_params.targetUserName` is type `string` in audit schema
- [x] Verified `arun+user@databricks.com` added to `metastore-admin-users` now appears in detection output
- [x] Verified child groups (`metastore_second_path`, `sfe-team-members`, `brickhound_child_group`) now resolved and included in expanded group filter